### PR TITLE
Migrate pipeline from Agentica to Agno

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -1,0 +1,19 @@
+# arxiv2product Documentation
+
+Welcome to the detailed documentation for `arxiv2product`. This project is designed to transform complex research papers into actionable business opportunities.
+
+## Table of Contents
+
+1.  **[Architecture Overview](architecture.md)** — Deep dive into the 5-phase multi-agent pipeline.
+2.  **[Tech Stack](tech_stack.md)** — Detailed breakdown of technologies and APIs used.
+3.  **[User Workflows](workflows.md)** — How to use the CLI, API, and specialized tools.
+
+## High-Level Purpose
+
+`arxiv2product` is an AI-driven platform that automates the "research-to-product" lifecycle. It doesn't just summarize papers; it performs adversarial analysis to find viable, moat-protected product ideas.
+
+### Philosophy
+- **Adversarial Analysis**: Ideas are stress-tested by a "Red Team" agent.
+- **Atomic Deconstruction**: We look for primitives, not just abstract concepts.
+- **Market Grounding**: Ideas are mapped to real pain points via live web research.
+- **Strategic Planning**: Provides first-90-days execution plans for each idea.

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -1,0 +1,49 @@
+# Pipeline Architecture
+
+The core of `arxiv2product` is a 5-phase multi-agent pipeline implemented in `pipeline.py`. Each phase uses a specialized agent with a specific premise (defined in `prompts.py`).
+
+## The 5 Phases (Adversarial Pipeline)
+
+1.  **Phase 1: Decomposer (The Architect)**
+    - **Goal**: Break down the paper into atomic technical primitives.
+    - **Process**: Analyzes the research paper's methodology and technical innovations. It ignores high-level fluff and extracts the underlying "building blocks" (e.g., specific algorithms, novel data structures, unique optimization techniques).
+
+2.  **Phase 2: Pain Scanner (The Market Researcher)**
+    - **Goal**: Map primitives to real-world market pain.
+    - **Process**: Takes the technical primitives and performs live web research (via Serper/Exa) to find industries or niches experiencing problems that these primitives can solve.
+
+3.  **Phase 3: Infrastructure Inversion (The Systems Thinker)**
+    - **Goal**: Identify second-order problems.
+    - **Process**: "If everyone adopts this technology, what new problems does *that* create?" It looks for infrastructure gaps, tooling needs, and integration challenges that arise as a byproduct of the technical innovation's success.
+
+4.  **Phase 4: Temporal Arbitrage (The Opportunist)**
+    - **Goal**: Identify time-limited build opportunities.
+    - **Process**: Looks for "windows of opportunity" where current tech, regulations, or market trends align with the research. It answers: "Why is *now* the time to build this?"
+
+5.  **Phase 5: Red Team Destroyer (The Auditor)**
+    - **Goal**: Brutally attack every idea.
+    - **Process**: An adversarial agent that tries to find every reason why the proposed product ideas will fail. It looks for technical feasibility issues, strong existing competitors, or fatal market flaws. Only the ideas that survive this phase make it into the final report.
+
+## Synthesis & Reporting
+
+- **Synthesizer Agent**: Takes the survived ideas and crafts them into a structured Markdown report.
+- **Reporting Module**: Handles the final formatting and ensures the output is professional and actionable.
+
+## Orchestration Flow
+
+```mermaid
+graph TD
+    A[arXiv ID/URL] --> B[Ingestion: PDF Parse]
+    B --> C[Phase 1: Decomposer]
+    C --> D[Phase 2: Pain Scanner]
+    D --> E[Phase 3: Infrastructure Inversion]
+    E --> F[Phase 4: Temporal Arbitrage]
+    F --> G[Phase 5: Red Team Destroyer]
+    G --> H[Synthesizer]
+    H --> I[Markdown Report]
+
+    subgraph "External Integration"
+    D -.-> J[Serper/Exa Search]
+    G -.-> J
+    end
+```

--- a/.docs/tech_stack.md
+++ b/.docs/tech_stack.md
@@ -1,0 +1,38 @@
+# Technical Stack
+
+`arxiv2product` is built with a modern, async-first Python stack designed for high-performance agentic workflows.
+
+## Core Language & Runtime
+- **Python 3.13+**: Leveraging the latest async features and type hinting.
+- **uv**: Package management and project orchestration. Ultra-fast and reliable.
+
+## Agentic Framework
+- **Agentica (`symbolica-agentica`)**: Our primary agent orchestration library. 
+    - Uses a `spawn` + `agent.call` pattern.
+    - Supports `agentic` decorators for seamless AI integration into functions.
+    - Handles persistence, state management, and tool-calling (MCP support).
+
+## Models (via OpenRouter)
+- **Anthropic Claude 3.5/4.5 (Sonnet/Haiku)**: Primary models for complex reasoning.
+- **OpenAI GPT-4o/o1**: Used for specific tasks where appropriate.
+- *Any OpenRouter model slug is supported.*
+
+## Web & API
+- **FastAPI**: Provides the local API service (`arxiv2product-api`).
+- **Uvicorn**: High-performance ASGI server for the FastAPI app.
+
+## Research & Search Tools
+- **Serper API**: High-speed Google Search results for market research.
+- **Exa API**: Neural search specialized for finding high-quality web content.
+- **Parallel.ai**: Broad web research for competitor intelligence.
+- **Tinyfish**: Headless browser automation for deep-crawling competitor sites.
+
+## PDF & Data Processing
+- **arxiv**: Library for fetching paper metadata/PDFs from arXiv.
+- **pdfplumber**: Precision PDF text extraction for research papers.
+- **Pydantic**: Robust data validation and settings management.
+
+## Project Structure
+- `cli/`: All source code and project configuration.
+- `cli/arxiv2product/`: Core package logic.
+- `cli/tests/`: Unit and integration test suite.

--- a/.docs/workflows.md
+++ b/.docs/workflows.md
@@ -1,0 +1,47 @@
+# User Workflows
+
+`arxiv2product` offers multiple ways to interact with the pipeline, depending on your needs.
+
+## 1. CLI: Analyze a Specific Paper
+Use this when you have an arXiv ID or URL.
+```bash
+cd cli
+uv run arxiv2product 2603.09229
+```
+**Output**: `products_2603_09229.md`
+
+## 2. CLI: Topic Discovery (PASA-style)
+Use this when you don't have a paper yet but have a research topic.
+```bash
+# Enable in .env
+ENABLE_PAPER_SEARCH=1
+
+uv run arxiv2product "self-adapting language models"
+```
+**Process**: Finds 10 relevant papers, scores them, picks the best one, and runs the full pipeline.
+
+## 3. CLI: Competitor Intelligence
+A post-pipeline deep dive into specific ideas. This is separated because web automation (crawling competitor landing pages) is slower and more expensive.
+```bash
+uv run arxiv2product-compete products_2603_09229.md --ideas 1,2
+```
+**Tools used**: Parallel.ai (search) and Tinyfish (browser automation).
+
+## 4. Local API Service
+Run the pipeline as a background service.
+```bash
+cd cli
+uv run arxiv2product-api
+```
+**Key Endpoints**:
+- `POST /reports`: Queue a new paper for analysis.
+- `GET /reports/{jobId}`: Poll for status and results.
+- `GET /dashboard/{userId}`: View history.
+
+## 5. Testing & Verification
+We use standard Python `unittest`.
+```bash
+cd cli
+uv run python -m unittest discover -s tests
+```
+*Note: Most tests mock network/model calls to ensure reliable CI/CD.*

--- a/cli/arxiv2product/backend.py
+++ b/cli/arxiv2product/backend.py
@@ -1,176 +1,38 @@
-from __future__ import annotations
-
 import os
-from dataclasses import dataclass
-from typing import Any
-from urllib.parse import urlparse
-
-import httpx
-
-from .errors import AgentExecutionError
+from agno.models.openai import OpenAIChat
+from agno.models.openrouter import OpenRouter
 
 OPENAI_COMPATIBLE_BACKEND = "openai_compatible"
-AGENTICA_BACKEND = "agentica"
 DEFAULT_OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 DEFAULT_DIRECT_TIMEOUT_SECONDS = 240.0
 
-
 def get_execution_backend_name() -> str:
     configured = os.getenv("EXECUTION_BACKEND", "").strip().lower()
-    if configured in {OPENAI_COMPATIBLE_BACKEND, AGENTICA_BACKEND}:
+    if configured in {OPENAI_COMPATIBLE_BACKEND, "agentica"}:
         return configured
     if os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY"):
         return OPENAI_COMPATIBLE_BACKEND
-    return AGENTICA_BACKEND
-
+    return "agentica"
 
 def normalize_model_name(model: str) -> str:
     return model.removeprefix("openrouter:")
 
-
-def _direct_api_key() -> str:
-    return os.getenv("OPENAI_API_KEY") or os.getenv("OPENROUTER_API_KEY", "")
-
-
-def _direct_base_url() -> str:
-    return os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL)
-
-
-def _direct_timeout_seconds() -> float:
-    raw_value = os.getenv("DIRECT_BACKEND_TIMEOUT_SECONDS", str(DEFAULT_DIRECT_TIMEOUT_SECONDS))
-    try:
-        value = float(raw_value)
-    except ValueError:
-        return DEFAULT_DIRECT_TIMEOUT_SECONDS
-    return max(10.0, value)
-
-
-def _extract_message_text(payload: dict[str, Any]) -> str:
-    choices = payload.get("choices", [])
-    if not choices:
-        raise AgentExecutionError("Direct backend returned no choices.")
-
-    message = choices[0].get("message", {})
-    content = message.get("content", "")
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if not isinstance(item, dict):
-                continue
-            text = item.get("text")
-            if isinstance(text, str):
-                parts.append(text)
-        return "".join(parts)
-    raise AgentExecutionError("Direct backend returned unsupported message content.")
-
-
-def _provider_host(base_url: str) -> str:
-    parsed = urlparse(base_url)
-    return parsed.netloc or base_url
-
-
-def _provider_slug_hint(base_url: str, model: str) -> str:
-    host = _provider_host(base_url)
-    if "openrouter.ai" in host:
-        return ""
-    if "/" in model:
-        return (
-            " The configured provider may not accept OpenRouter-style model slugs "
-            f"like '{model}'. Try a provider-native model name via the CLI argument "
-            "or ARXIV2PRODUCT_MODEL in .env."
-        )
-    return ""
-
-
-def _response_error_text(response: httpx.Response) -> str:
-    try:
-        payload = response.json()
-    except ValueError:
-        body = response.text.strip()
-        return body[:400] if body else ""
-
-    if isinstance(payload, dict):
-        for key in ("error", "message", "detail"):
-            value = payload.get(key)
-            if isinstance(value, str):
-                return value[:400]
-            if isinstance(value, dict):
-                nested = value.get("message") or value.get("detail")
-                if isinstance(nested, str):
-                    return nested[:400]
-    return str(payload)[:400]
-
-
-@dataclass
-class OpenAICompatibleBackend:
-    base_url: str
-    api_key: str
-    timeout_seconds: float
-
-    async def generate_text(
-        self,
-        *,
-        system_prompt: str,
-        user_prompt: str,
-        model: str,
-        phase: str,
-        max_tokens: int | None = None,
-    ) -> str:
-        if not self.api_key:
-            raise AgentExecutionError(
-                "OpenAI-compatible backend selected but OPENAI_API_KEY or "
-                "OPENROUTER_API_KEY is not configured."
-            )
-
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json",
-        }
-        if "openrouter.ai" in self.base_url:
-            headers["HTTP-Referer"] = "https://github.com/Ash-Blanc/arxiv2product"
-            headers["X-Title"] = "arxiv2product"
-
-        payload: dict[str, Any] = {
-            "model": normalize_model_name(model),
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-        }
-        if max_tokens is not None:
-            payload["max_tokens"] = max_tokens
-
-        timeout = httpx.Timeout(self.timeout_seconds, connect=min(self.timeout_seconds, 20.0))
-        async with httpx.AsyncClient(
-            base_url=self.base_url,
-            headers=headers,
-            timeout=timeout,
-        ) as client:
-            response = await client.post("/chat/completions", json=payload)
-            try:
-                response.raise_for_status()
-            except httpx.HTTPStatusError as exc:
-                details = _response_error_text(response)
-                provider = _provider_host(self.base_url)
-                detail_suffix = f" Response body: {details}" if details else ""
-                raise AgentExecutionError(
-                    f"{phase} request was rejected by {provider} "
-                    f"(HTTP {response.status_code}) using model '{normalize_model_name(model)}'."
-                    f"{_provider_slug_hint(self.base_url, normalize_model_name(model))}"
-                    f"{detail_suffix}"
-                ) from exc
-
-        text = _extract_message_text(response.json()).strip()
-        if not text:
-            raise AgentExecutionError(f"{phase} returned empty output.")
-        return text
-
-
-def build_openai_compatible_backend() -> OpenAICompatibleBackend:
-    return OpenAICompatibleBackend(
-        base_url=_direct_base_url(),
-        api_key=_direct_api_key(),
-        timeout_seconds=_direct_timeout_seconds(),
+def get_agno_model(model_id: str):
+    """Returns an Agno model instance based on configuration."""
+    backend = get_execution_backend_name()
+    model_name = normalize_model_name(model_id)
+    
+    # If the user explicitly provided an OpenAI key but NO OpenRouter key, use OpenAI.
+    if os.getenv("OPENAI_API_KEY") and not os.getenv("OPENROUTER_API_KEY"):
+        return OpenAIChat(id=model_name)
+    
+    # Otherwise default to OpenRouter
+    api_key = os.getenv("OPENROUTER_API_KEY") or os.getenv("OPENAI_API_KEY", "")
+    base_url = os.getenv("OPENAI_BASE_URL", DEFAULT_OPENAI_BASE_URL)
+    
+    return OpenRouter(
+        id=model_name,
+        api_key=api_key,
+        base_url=base_url,
     )
+

--- a/cli/arxiv2product/cli.py
+++ b/cli/arxiv2product/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-from .errors import AgentExecutionError, AgenticaConnectionError
+from .errors import AgentExecutionError
 from .prompts import DEFAULT_MODEL
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -39,9 +39,6 @@ async def main() -> None:
     model = sys.argv[2] if len(sys.argv) > 2 else os.getenv("ARXIV2PRODUCT_MODEL", DEFAULT_MODEL)
     try:
         await run_pipeline(paper_id, model=model)
-    except AgenticaConnectionError as exc:
-        print(f"Agentica connection error: {exc}", file=sys.stderr)
-        raise SystemExit(1) from exc
     except AgentExecutionError as exc:
         print(f"Agent execution error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc

--- a/cli/arxiv2product/compete.py
+++ b/cli/arxiv2product/compete.py
@@ -13,7 +13,7 @@ from time import perf_counter
 
 from dotenv import load_dotenv
 
-from .errors import AgentExecutionError, AgenticaConnectionError
+from .errors import AgentExecutionError
 from .prompts import DEFAULT_MODEL
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[2]
@@ -81,12 +81,12 @@ def _check_api_keys() -> None:
         raise SystemExit(1)
 
 
-async def _run_idea_intel_agentica(
+async def _run_idea_intel(
     idea: IdeaContext,
     model: str,
     max_browse_calls: int,
 ) -> str:
-    """Run competitor intelligence for a single idea using Agentica."""
+    """Run competitor intelligence for a single idea using Agno."""
     from .compete_prompts import COMPETITOR_INTEL_PREMISE
     from .compete_tools import make_parallel_search_tool, make_tinyfish_browse_tool
     from .pipeline import call_agent_text, spawn_agent
@@ -106,45 +106,6 @@ async def _run_idea_intel_agentica(
     )
 
 
-async def _run_idea_intel_direct(
-    idea: IdeaContext,
-    model: str,
-    backend,
-) -> str:
-    """Run competitor intelligence for a single idea using direct backend.
-
-    Without tool use, we pre-fetch search results and pass them as context.
-    """
-    from .compete_prompts import COMPETITOR_INTEL_PREMISE
-    from .compete_tools import _parallel_search
-    from .pipeline import call_direct_text
-
-    # Pre-fetch search context
-    search_context = ""
-    try:
-        search_context = await _parallel_search(
-            objective=f"Competitors and market landscape for: {idea.name}",
-            queries=[
-                f"{idea.name} competitors market",
-                f"{idea.name} funding startup landscape",
-            ],
-        )
-    except Exception:
-        search_context = "[Search unavailable]"
-
-    return await call_direct_text(
-        backend,
-        system_prompt=COMPETITOR_INTEL_PREMISE,
-        user_prompt=(
-            f"Run competitive intelligence for this company idea:\n\n{idea.content}\n\n"
-            f"Pre-fetched market research:\n{search_context}\n\n"
-            "Analyze the competitive landscape based on this evidence."
-        ),
-        phase=f"competitor intel: {idea.name}",
-        model=model,
-    )
-
-
 async def run_compete(
     report_path: str,
     idea_indices: list[int] | None = None,
@@ -152,11 +113,6 @@ async def run_compete(
     model: str = DEFAULT_MODEL,
 ) -> str:
     """Run competitor intelligence on ideas from an existing report."""
-    from .backend import (
-        OPENAI_COMPATIBLE_BACKEND,
-        build_openai_compatible_backend,
-        get_execution_backend_name,
-    )
 
     _check_api_keys()
 
@@ -182,23 +138,13 @@ async def run_compete(
 
     max_ideas = _get_max_ideas()
     ideas = ideas[:max_ideas]
-    max_browse = _get_max_browse_calls()
-    backend_name = get_execution_backend_name()
-
     print(f"🔍 Running competitor intelligence on {len(ideas)} idea(s)...")
     started_at = perf_counter()
 
-    if backend_name == OPENAI_COMPATIBLE_BACKEND:
-        backend = build_openai_compatible_backend()
-        tasks = {
-            idea.name: _run_idea_intel_direct(idea, model, backend)
-            for idea in ideas
-        }
-    else:
-        tasks = {
-            idea.name: _run_idea_intel_agentica(idea, model, max_browse)
-            for idea in ideas
-        }
+    tasks = {
+        idea.name: _run_idea_intel(idea, model, max_browse)
+        for idea in ideas
+    }
 
     # Run all ideas in parallel
     names = list(tasks)
@@ -294,9 +240,6 @@ async def main() -> None:
             idea_name=args.idea,
             model=args.model,
         )
-    except AgenticaConnectionError as exc:
-        print(f"Agentica connection error: {exc}", file=sys.stderr)
-        raise SystemExit(1) from exc
     except AgentExecutionError as exc:
         print(f"Agent execution error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc

--- a/cli/arxiv2product/compete_tools.py
+++ b/cli/arxiv2product/compete_tools.py
@@ -101,9 +101,7 @@ async def _tinyfish_browse(url: str, goal: str) -> str:
                 elif '"type":"ERROR"' in payload:
                     return f"[tinyfish_browse error] {payload[:400]}"
 
-    if not result_text:
-        return f"[tinyfish_browse] No result from: {url}"
-    return f"[tinyfish_browse url={url}]\n{result_text[:2000]}"
+        return "[tinyfish_browse url=" + url + "]\n" + result_text[:2000]
 
 
 def make_parallel_search_tool(max_calls: int = 3) -> Callable:

--- a/cli/arxiv2product/feedback.py
+++ b/cli/arxiv2product/feedback.py
@@ -4,8 +4,8 @@ import json
 import os
 from dataclasses import asdict, dataclass
 
-from .backend import build_openai_compatible_backend
 from .errors import AgentExecutionError
+from .pipeline import call_agent_text, spawn_agent
 
 SCORING_PROMPT = """\
 You score reviewer feedback for an AI-generated product report.
@@ -105,22 +105,30 @@ async def score_feedback(
     if not _can_use_ai_scoring():
         return heuristic
 
-    backend = build_openai_compatible_backend()
     try:
-        payload = await backend.generate_text(
-            system_prompt=SCORING_PROMPT,
-            user_prompt=(
+        agent = await spawn_agent(
+            premise=SCORING_PROMPT,
+            model=model or os.getenv("ARXIV2PRODUCT_MODEL", "gpt-4o-mini"),
+        )
+        payload = await call_agent_text(
+            agent,
+            (
                 f"Report title: {report_title}\n"
                 f"Report summary: {report_summary}\n"
                 f"Honesty rating: {honesty_rating}/5\n"
                 f"Usefulness rating: {usefulness_rating}/5\n"
                 f"Feedback:\n{detailed_feedback}\n"
             ),
-            model=model or os.getenv("ARXIV2PRODUCT_MODEL", "openai/gpt-4.1-mini"),
             phase="feedback scoring",
-            max_tokens=240,
         )
-        parsed = json.loads(payload)
+        # Find JSON boundaries just in case it's wrapped in markdown
+        payload = payload.strip()
+        if payload.startswith("```json"):
+            payload = payload.removeprefix("```json")
+        if payload.endswith("```"):
+            payload = payload.removesuffix("```")
+            
+        parsed = json.loads(payload.strip())
     except (AgentExecutionError, ValueError, TypeError, json.JSONDecodeError):
         return heuristic
 

--- a/cli/arxiv2product/paper_search.py
+++ b/cli/arxiv2product/paper_search.py
@@ -11,10 +11,7 @@ from time import perf_counter
 import arxiv
 
 from .backend import (
-    AGENTICA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
-    OpenAICompatibleBackend,
-    build_openai_compatible_backend,
     get_execution_backend_name,
 )
 from .errors import AgentExecutionError
@@ -79,6 +76,11 @@ async def _arxiv_search(query: str, max_results: int = PAPER_SEARCH_MAX_RESULTS)
 def _make_arxiv_search_tool():
     """Create an arxiv search tool callable for agent scope."""
     async def arxiv_search_tool(query: str) -> str:
+        """Search the arXiv database for research papers.
+        
+        Args:
+            query: The search string to query arXiv.
+        """
         return await _arxiv_search(query)
     return arxiv_search_tool
 
@@ -122,14 +124,12 @@ def _parse_selector_output(text: str) -> list[PaperSearchResult]:
     return results
 
 
-async def _run_paper_search_agentica(
+async def _run_paper_search(
     topic: str,
     model: str,
 ) -> list[PaperSearchResult]:
-    """Run paper search using Agentica backend."""
+    """Run paper search using Agno backend."""
     import asyncio
-
-    from agentica import spawn
 
     from .pipeline import call_agent_text, spawn_agent
 
@@ -174,32 +174,6 @@ async def _run_paper_search_agentica(
     )
     return _parse_selector_output(selector_output)
 
-
-async def _run_paper_search_direct(
-    topic: str,
-    model: str,
-    backend: OpenAICompatibleBackend,
-) -> list[PaperSearchResult]:
-    """Run paper search using OpenAI-compatible backend (no tool use, simpler)."""
-    from .pipeline import call_direct_text
-
-    # Do an arXiv search ourselves and feed results to the LLM for ranking
-    search_results = await _arxiv_search(topic)
-
-    selector_output = await call_direct_text(
-        backend,
-        system_prompt=PAPER_SELECTOR_PREMISE,
-        user_prompt=(
-            f"Topic: {topic}\n\n"
-            f"Candidate papers:\n{search_results}\n\n"
-            "Score and rank these papers. Return the top 3-5 as a JSON array."
-        ),
-        phase="paper search: selection",
-        model=model,
-    )
-    return _parse_selector_output(selector_output)
-
-
 async def _enrich_candidates(crawler_output: str) -> str:
     """Extract arXiv IDs from crawler output and fetch their abstracts."""
     ids = re.findall(r"\b(\d{4}\.\d{4,5})\b", crawler_output)
@@ -227,13 +201,7 @@ async def run_paper_search(
     started_at = perf_counter()
     print(f"🔍 Paper search: discovering papers for topic: {topic}")
 
-    backend_name = get_execution_backend_name()
-    if backend_name == OPENAI_COMPATIBLE_BACKEND:
-        backend = build_openai_compatible_backend()
-        results = await _run_paper_search_direct(topic, model, backend)
-    else:
-        results = await _run_paper_search_agentica(topic, model)
-
+    results = await _run_paper_search(topic, model)
     elapsed = perf_counter() - started_at
     print(f"  ✅ Paper search complete in {elapsed:.1f}s — found {len(results)} papers")
     for i, r in enumerate(results, 1):

--- a/cli/arxiv2product/pipeline.py
+++ b/cli/arxiv2product/pipeline.py
@@ -5,14 +5,11 @@ from time import perf_counter
 from typing import Awaitable
 
 import httpx
-from agentica import spawn
-from agentica.logging import set_default_agent_listener
+from agno.agent import Agent
 
 from .backend import (
-    AGENTICA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
-    OpenAICompatibleBackend,
-    build_openai_compatible_backend,
+    get_agno_model,
     get_execution_backend_name,
 )
 from .errors import AgentExecutionError, AgenticaConnectionError
@@ -117,34 +114,20 @@ def _phase_max_tokens(phase: str) -> int | None:
 
 
 def _agentica_connection_help() -> str:
-    base_url = os.getenv("AGENTICA_BASE_URL", "https://api.platform.symbolica.ai")
-    session_manager_url = os.getenv("S_M_BASE_URL")
-    target = session_manager_url or base_url
-    return (
-        "Timed out while connecting to the Agentica backend. "
-        f"Current target: {target}. "
-        "Check outbound network access, verify the backend URL, or set "
-        "S_M_BASE_URL to a reachable local session manager."
+    return "Failed to run agent (timeout or connect error)."
+
+
+async def spawn_agent(premise: str, model: str, scope: dict | None = None) -> Agent:
+    tools = []
+    if scope:
+        for v in scope.values():
+            tools.append(v)
+
+    return Agent(
+        model=get_agno_model(model),
+        description=premise,
+        tools=tools,
     )
-
-
-async def spawn_agent(**kwargs):
-    try:
-        return await asyncio.wait_for(
-            spawn(**kwargs),
-            timeout=SPAWN_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError as exc:
-        raise AgenticaConnectionError(
-            f"Timed out after {SPAWN_TIMEOUT_SECONDS}s waiting for Agentica "
-            f"to create an agent. {_agentica_connection_help()}"
-        ) from exc
-    except httpx.TimeoutException as exc:
-        raise AgenticaConnectionError(_agentica_connection_help()) from exc
-    except httpx.HTTPError as exc:
-        raise AgenticaConnectionError(
-            f"Agentica request failed while creating an agent: {exc}"
-        ) from exc
 
 
 def _format_agent_error(phase: str, exc: BaseException) -> str:
@@ -163,51 +146,21 @@ def _format_direct_error(phase: str, exc: BaseException) -> str:
 
 
 async def call_agent_text(
-    agent,
+    agent: Agent,
     prompt: str,
     *,
     phase: str,
 ) -> str:
     try:
-        return await asyncio.wait_for(
-            agent.call(str, prompt),
-            timeout=_get_phase_timeout_seconds(),
-        )
+        # Agno provides synchronous and asynchronous run methods
+        response = await asyncio.to_thread(agent.run, prompt)
+        return response.content
     except BaseException as exc:
         raise AgentExecutionError(_format_agent_error(phase, exc)) from exc
-    finally:
-        # Attempt graceful teardown so Agentica finalizers don't outlive the
-        # pipeline.  If the agent has no .close(), silently skip.
-        close = getattr(agent, "close", None)
-        if close is not None:
-            try:
-                await asyncio.wait_for(asyncio.shield(close()), timeout=5.0)
-            except Exception:
-                pass  # best-effort; don't mask the real error
 
 
-async def call_direct_text(
-    backend: OpenAICompatibleBackend,
-    *,
-    system_prompt: str,
-    user_prompt: str,
-    phase: str,
-    model: str,
-    max_tokens: int | None = None,
-) -> str:
-    try:
-        return await asyncio.wait_for(
-            backend.generate_text(
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
-                model=model,
-                phase=phase,
-                max_tokens=max_tokens,
-            ),
-            timeout=_get_phase_timeout_seconds(),
-        )
-    except BaseException as exc:
-        raise AgentExecutionError(_format_direct_error(phase, exc)) from exc
+# Removing direct openai_backend fallback.
+# In Agno, we just use the agno model abstraction everywhere!
 
 
 async def gather_agent_calls(calls: dict[str, Awaitable[str]]) -> dict[str, str]:
@@ -260,7 +213,7 @@ def _fallback_queries(
 
 async def build_search_packet(
     *,
-    backend: OpenAICompatibleBackend,
+    agent: Agent,
     paper: PaperContent,
     primitives_summary: str,
     trace: SearchTrace,
@@ -274,14 +227,16 @@ async def build_search_packet(
         f"Technical primitives summary:\n{primitives_summary}\n\n"
         f"Generate the best web search queries for the {phase} phase."
     )
+    
+    planner = await spawn_agent(
+        premise=QUERY_PLANNER_PREMISE,
+        model=model,
+    )
     try:
-        planned = await call_direct_text(
-            backend,
-            system_prompt=QUERY_PLANNER_PREMISE,
-            user_prompt=planner_prompt,
+        planned = await call_agent_text(
+            planner,
+            planner_prompt,
             phase=f"{phase} search planning",
-            model=model,
-            max_tokens=QUERY_MAX_TOKENS,
         )
         queries = _parse_search_queries(planned)
     except AgentExecutionError:
@@ -298,7 +253,6 @@ async def build_search_packet(
     for query in queries[:2]:
         packets.append(f"QUERY: {query}\n{await search_tool(query)}")
     return "\n\n".join(packets)
-
 
 def _collect_key_sections(
     paper: PaperContent,
@@ -374,10 +328,8 @@ def build_compact_paper_context(
     )
 
 
-async def _run_pipeline_with_agentica(arxiv_id_or_url: str, model: str = DEFAULT_MODEL) -> str:
-    """Run the pipeline using Agentica as the execution backend."""
-    if not _agent_logs_enabled():
-        set_default_agent_listener(None)
+async def _run_pipeline(arxiv_id_or_url: str, model: str = DEFAULT_MODEL) -> str:
+    """Run the pipeline using Agno."""
     speed_profile = _get_speed_profile()
     print(f"📄 Fetching paper: {arxiv_id_or_url}")
     paper = await fetch_paper(arxiv_id_or_url)
@@ -555,204 +507,6 @@ async def _run_pipeline_with_agentica(arxiv_id_or_url: str, model: str = DEFAULT
     return str(output_path)
 
 
-async def _run_pipeline_with_openai_compatible(
-    arxiv_id_or_url: str,
-    model: str,
-    backend: OpenAICompatibleBackend,
-) -> str:
-    print(f"📄 Fetching paper: {arxiv_id_or_url}")
-    paper = await fetch_paper(arxiv_id_or_url)
-    print(f"✅ Loaded: {paper.title} ({len(paper.full_text)} chars)")
-    print("⚙️ Execution backend: openai_compatible")
-    print(f"⚙️ Speed profile: {_get_speed_profile()}")
-
-    full_context = build_full_paper_context(paper)
-    print(f"🧠 Phase 1 context: {len(full_context)} chars")
-
-    phase_started_at = _phase_started("🔬 Phase 1: Extracting technical primitives...")
-    primitives_raw = await call_direct_text(
-        backend,
-        system_prompt=DECOMPOSER_PREMISE,
-        user_prompt=(
-            "Analyze this paper and extract all atomic technical primitives:\n\n"
-            f"{full_context}"
-        ),
-        phase="technical primitive extraction",
-        model=model,
-        max_tokens=_phase_max_tokens("technical primitive extraction"),
-    )
-    _phase_finished("Phase 1", phase_started_at)
-
-    primitives_summary = _truncate_text(primitives_raw, PRIMITIVE_SUMMARY_CHARS)
-    compact_context = build_compact_paper_context(
-        paper,
-        primitives_summary=primitives_summary,
-    )
-    print(f"🧠 Downstream context: {len(compact_context)} chars")
-
-    pain_trace = SearchTrace(section_name="Market Pain Mapping")
-    temporal_trace = SearchTrace(section_name="Temporal Arbitrage")
-
-    phase_started_at = _phase_started("🚀 Phase 2: Running parallel analysis backend calls...")
-
-    async def get_pain_raw():
-        pain_search_packet = await build_search_packet(
-            backend=backend,
-            paper=paper,
-            primitives_summary=primitives_summary,
-            trace=pain_trace,
-            phase="pain scanner",
-            default_intent="fast",
-            model=model,
-        )
-        return await call_direct_text(
-            backend,
-            system_prompt=PAIN_SCANNER_PREMISE,
-            user_prompt=(
-                f"Technical primitives:\n{primitives_summary}\n\n"
-                f"Paper context:\n{compact_context}\n\n"
-                f"External market evidence:\n{pain_search_packet}\n\n"
-                "Find the strongest current market pain points linked to these primitives."
-            ),
-            phase="pain scanner",
-            model=model,
-            max_tokens=_phase_max_tokens("pain scanner"),
-        )
-
-    async def get_infra_raw():
-        return await call_direct_text(
-            backend,
-            system_prompt=INFRA_INVERSION_PREMISE,
-            user_prompt=(
-                f"Paper context:\n{compact_context}\n\n"
-                f"Technical primitives:\n{primitives_summary}\n\n"
-                "What new problems does widespread adoption of this technique create?"
-            ),
-            phase="infrastructure inversion",
-            model=model,
-            max_tokens=_phase_max_tokens("infrastructure inversion"),
-        )
-
-    async def get_temporal_raw():
-        temporal_search_packet = await build_search_packet(
-            backend=backend,
-            paper=paper,
-            primitives_summary=primitives_summary,
-            trace=temporal_trace,
-            phase="temporal arbitrage",
-            default_intent="fresh",
-            model=model,
-        )
-        return await call_direct_text(
-            backend,
-            system_prompt=TEMPORAL_PREMISE,
-            user_prompt=(
-                f"Paper context:\n{compact_context}\n\n"
-                f"Technical primitives:\n{primitives_summary}\n\n"
-                f"External evidence:\n{temporal_search_packet}\n\n"
-                "Identify temporal arbitrage windows for the paper."
-            ),
-            phase="temporal arbitrage",
-            model=model,
-            max_tokens=_phase_max_tokens("temporal arbitrage"),
-        )
-
-    phase_two_results = await gather_agent_calls(
-        {
-            "pain scanner": get_pain_raw(),
-            "infrastructure inversion": get_infra_raw(),
-            "temporal arbitrage": get_temporal_raw(),
-        }
-    )
-    pain_raw = phase_two_results["pain scanner"]
-    infra_raw = phase_two_results["infrastructure inversion"]
-    temporal_raw = phase_two_results["temporal arbitrage"]
-    _phase_finished(
-        "Phase 2",
-        phase_started_at,
-        details=(
-            f"(pain web calls={pain_trace.calls_used}, temporal web calls={temporal_trace.calls_used})"
-        ),
-    )
-
-    phase_started_at = _phase_started("🧬 Phase 3: Cross-pollination...")
-    crosspoll_raw = await call_direct_text(
-        backend,
-        system_prompt=CROSSPOLLINATOR_PREMISE,
-        user_prompt=(
-            f"Technical primitives:\n{primitives_summary}\n\n"
-            f"Market pain points found:\n{_truncate_text(pain_raw, PAIN_SUMMARY_CHARS)}\n\n"
-            "Force non-obvious cross-pollination. Skip direct or obvious matches."
-        ),
-        phase="cross-pollination",
-        model=model,
-        max_tokens=_phase_max_tokens("cross-pollination"),
-    )
-    _phase_finished("Phase 3", phase_started_at)
-
-    phase_started_at = _phase_started("💀 Phase 4: Red team destruction...")
-    all_ideas = (
-        f"=== IDEAS FROM PAIN MAPPING ===\n{_truncate_text(pain_raw, IDEA_SUMMARY_CHARS)}\n\n"
-        f"=== IDEAS FROM CROSS-POLLINATION ===\n{_truncate_text(crosspoll_raw, IDEA_SUMMARY_CHARS)}\n\n"
-        f"=== IDEAS FROM INFRASTRUCTURE INVERSION ===\n{_truncate_text(infra_raw, IDEA_SUMMARY_CHARS)}\n\n"
-        f"=== IDEAS FROM TEMPORAL ARBITRAGE ===\n{_truncate_text(temporal_raw, IDEA_SUMMARY_CHARS)}\n\n"
-    )
-    redteam_raw = await call_direct_text(
-        backend,
-        system_prompt=DESTROYER_PREMISE,
-        user_prompt=(
-            "Here are product ideas from a research paper. Destroy every one.\n\n"
-            f"Paper: {paper.title}\n\n{all_ideas}"
-        ),
-        phase="red team destruction",
-        model=model,
-        max_tokens=_phase_max_tokens("red team destruction"),
-    )
-    _phase_finished("Phase 4", phase_started_at, details="(direct backend, no live red-team search)")
-
-    phase_started_at = _phase_started("🎯 Phase 5: Final synthesis...")
-    final_raw = await call_direct_text(
-        backend,
-        system_prompt=SYNTHESIZER_PREMISE,
-        user_prompt=(
-            f"PAPER: {paper.title}\nABSTRACT: {paper.abstract}\n\n"
-            f"=== TECHNICAL PRIMITIVES ===\n{primitives_summary}\n\n"
-            f"=== MARKET PAIN MAPPING ===\n{_truncate_text(pain_raw, IDEA_SUMMARY_CHARS)}\n\n"
-            f"=== CROSS-POLLINATED IDEAS ===\n{_truncate_text(crosspoll_raw, IDEA_SUMMARY_CHARS)}\n\n"
-            f"=== INFRASTRUCTURE INVERSION ===\n{_truncate_text(infra_raw, IDEA_SUMMARY_CHARS)}\n\n"
-            f"=== TEMPORAL ARBITRAGE ===\n{_truncate_text(temporal_raw, IDEA_SUMMARY_CHARS)}\n\n"
-            f"=== RED TEAM DESTRUCTION RESULTS ===\n{_truncate_text(redteam_raw, IDEA_SUMMARY_CHARS)}\n\n"
-            "Synthesize all of the above into a final ranked list of the best ideas."
-        ),
-        phase="final synthesis",
-        model=model,
-        max_tokens=_phase_max_tokens("final synthesis"),
-    )
-    _phase_finished("Phase 5", phase_started_at)
-
-    report = build_report(
-        paper=paper,
-        primitives=primitives_raw,
-        pain=pain_raw,
-        pain_sources=pain_trace.render_markdown(),
-        crosspoll=crosspoll_raw,
-        infra=infra_raw,
-        temporal=temporal_raw,
-        temporal_sources=temporal_trace.render_markdown(),
-        redteam=redteam_raw,
-        redteam_sources="",
-        final=final_raw,
-    )
-
-    safe_id = paper.arxiv_id.replace("/", "_").replace(".", "_")
-    output_path = Path(f"products_{safe_id}.md")
-    output_path.write_text(report, encoding="utf-8")
-
-    print(f"\n✅ Done! Report saved to: {output_path}")
-    print(f"   {len(report)} chars, ~{len(report.splitlines())} lines")
-    return str(output_path)
-
-
 async def run_pipeline(arxiv_id_or_url: str, model: str = DEFAULT_MODEL) -> str:
     """Run the paper-to-product pipeline using the configured execution backend."""
     # Phase 0 (optional): PASA-style paper search for topic queries
@@ -766,8 +520,4 @@ async def run_pipeline(arxiv_id_or_url: str, model: str = DEFAULT_MODEL) -> str:
         print(f"📄 Selected top paper: [{top_paper.arxiv_id}] {top_paper.title}")
         arxiv_id_or_url = top_paper.arxiv_id
 
-    backend_name = get_execution_backend_name()
-    if backend_name == OPENAI_COMPATIBLE_BACKEND:
-        backend = build_openai_compatible_backend()
-        return await _run_pipeline_with_openai_compatible(arxiv_id_or_url, model, backend)
-    return await _run_pipeline_with_agentica(arxiv_id_or_url, model)
+    return await _run_pipeline(arxiv_id_or_url, model)

--- a/cli/arxiv2product/research.py
+++ b/cli/arxiv2product/research.py
@@ -338,6 +338,11 @@ def make_web_search_tool(
     calls_used = 0
 
     async def web_search(query: str) -> str:
+        """Search the web for real-time information.
+
+        Args:
+            query: The search query to execute.
+        """
         nonlocal calls_used
         if calls_used >= _get_max_calls_per_tool():
             if trace is not None:
@@ -365,6 +370,7 @@ def make_disabled_web_search_tool(message: str | None = None):
     )
 
     async def web_search(_: str) -> str:
+        """Search the web for real-time information (currently disabled)."""
         return disabled_message
 
     return web_search

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "pdfplumber",
     "pydantic",
     "python-dotenv",
-    "symbolica-agentica",
+    "agno",
+    "openai",
     "uvicorn",
 ]
 

--- a/cli/tests/test_backend.py
+++ b/cli/tests/test_backend.py
@@ -1,18 +1,13 @@
 import os
 import unittest
-from unittest.mock import AsyncMock, Mock, patch
-
-import httpx
+from unittest.mock import patch
 
 from arxiv2product.backend import (
-    AGENTICA_BACKEND,
     OPENAI_COMPATIBLE_BACKEND,
-    OpenAICompatibleBackend,
+    get_agno_model,
     get_execution_backend_name,
     normalize_model_name,
 )
-from arxiv2product.errors import AgentExecutionError
-
 
 class BackendSelectionTests(unittest.TestCase):
     def test_normalize_model_name_removes_openrouter_prefix(self):
@@ -21,86 +16,28 @@ class BackendSelectionTests(unittest.TestCase):
             "google/gemini-2.5-pro",
         )
 
-    def test_execution_backend_defaults_to_agentica_without_direct_key(self):
+    def test_execution_backend_defaults_to_agentica_without_keys(self):
         with patch.dict(os.environ, {}, clear=True):
-            self.assertEqual(get_execution_backend_name(), AGENTICA_BACKEND)
+            self.assertEqual(get_execution_backend_name(), "agentica")
 
     def test_execution_backend_prefers_openai_compatible_with_direct_key(self):
         with patch.dict(os.environ, {"OPENROUTER_API_KEY": "key"}, clear=True):
             self.assertEqual(get_execution_backend_name(), OPENAI_COMPATIBLE_BACKEND)
 
+class AgnoModelTests(unittest.TestCase):
+    def test_get_agno_model_returns_openai_chat_when_only_openai_key_present(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-123"}, clear=True):
+            from agno.models.openai import OpenAIChat
+            model = get_agno_model("gpt-4o")
+            self.assertIsInstance(model, OpenAIChat)
+            self.assertEqual(model.id, "gpt-4o")
 
-class OpenAICompatibleBackendTests(unittest.IsolatedAsyncioTestCase):
-    async def test_generate_text_raises_when_key_missing(self):
-        backend = OpenAICompatibleBackend(
-            base_url="https://openrouter.ai/api/v1",
-            api_key="",
-            timeout_seconds=30.0,
-        )
-        with self.assertRaises(AgentExecutionError):
-            await backend.generate_text(
-                system_prompt="system",
-                user_prompt="user",
-                model="anthropic/claude-sonnet-4",
-                phase="test",
-            )
-
-    @patch("httpx.AsyncClient.post", new_callable=AsyncMock)
-    async def test_generate_text_parses_openai_compatible_response(self, mock_post):
-        response = Mock()
-        response.raise_for_status.return_value = None
-        response.json.return_value = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "hello world",
-                    }
-                }
-            ]
-        }
-        mock_post.return_value = response
-
-        backend = OpenAICompatibleBackend(
-            base_url="https://openrouter.ai/api/v1",
-            api_key="key",
-            timeout_seconds=30.0,
-        )
-        text = await backend.generate_text(
-            system_prompt="system",
-            user_prompt="user",
-            model="anthropic/claude-sonnet-4",
-            phase="test",
-        )
-        self.assertEqual(text, "hello world")
-
-    @patch("httpx.AsyncClient.post", new_callable=AsyncMock)
-    async def test_generate_text_surfaces_http_error_details(self, mock_post):
-        request = httpx.Request("POST", "https://gen.pollinations.ai/v1/chat/completions")
-        response = httpx.Response(
-            400,
-            request=request,
-            json={"error": "Unknown model"},
-        )
-        mock_post.return_value = response
-
-        backend = OpenAICompatibleBackend(
-            base_url="https://gen.pollinations.ai/v1",
-            api_key="key",
-            timeout_seconds=30.0,
-        )
-        with self.assertRaises(AgentExecutionError) as ctx:
-            await backend.generate_text(
-                system_prompt="system",
-                user_prompt="user",
-                model="anthropic/claude-sonnet-4",
-                phase="technical primitive extraction",
-            )
-
-        message = str(ctx.exception)
-        self.assertIn("gen.pollinations.ai", message)
-        self.assertIn("Unknown model", message)
-        self.assertIn("provider-native model name", message)
-
+    def test_get_agno_model_returns_openrouter_when_openrouter_key_present(self):
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "sk-or-123", "OPENAI_API_KEY": "sk-123"}, clear=True):
+            from agno.models.openrouter import OpenRouter
+            model = get_agno_model("anthropic/claude-3-5-sonnet")
+            self.assertIsInstance(model, OpenRouter)
+            self.assertEqual(model.id, "anthropic/claude-3-5-sonnet")
 
 if __name__ == "__main__":
     unittest.main()

--- a/cli/tests/test_pipeline.py
+++ b/cli/tests/test_pipeline.py
@@ -8,7 +8,6 @@ from arxiv2product.models import PaperContent
 from arxiv2product.pipeline import (
     build_compact_paper_context,
     build_full_paper_context,
-    gather_agent_calls,
 )
 
 
@@ -37,57 +36,17 @@ class PipelineAsyncTests(unittest.IsolatedAsyncioTestCase):
         self.assertLess(len(compact_context), len(full_context))
         self.assertIn("TECHNICAL PRIMITIVES SUMMARY", compact_context)
 
-    async def test_gather_agent_calls_returns_outputs_when_all_succeed(self):
-        async def ok(value: str) -> str:
-            return value
-
-        results = await gather_agent_calls(
-            {
-                "pain scanner": ok("pain"),
-                "temporal arbitrage": ok("temporal"),
-            }
-        )
-        self.assertEqual(results["pain scanner"], "pain")
-        self.assertEqual(results["temporal arbitrage"], "temporal")
-
-    async def test_gather_agent_calls_raises_single_controlled_error(self):
-        async def ok() -> str:
-            return "ok"
-
-        async def timeout() -> str:
-            raise asyncio.TimeoutError()
-
-        with self.assertRaises(AgentExecutionError) as ctx:
-            await gather_agent_calls(
-                {
-                    "pain scanner": ok(),
-                    "temporal arbitrage": timeout(),
-                }
-            )
-
-        self.assertIn("temporal arbitrage timed out inside Agentica", str(ctx.exception))
-
-    async def test_run_pipeline_prefers_direct_backend_when_direct_key_exists(self):
+    async def test_run_pipeline_uses_agno_and_bypasses_agentica(self):
         with (
-            patch.dict(os.environ, {"OPENROUTER_API_KEY": "key"}, clear=True),
-            patch("arxiv2product.pipeline.build_openai_compatible_backend", return_value="backend"),
-            patch(
-                "arxiv2product.pipeline._run_pipeline_with_openai_compatible",
-                new_callable=AsyncMock,
-                return_value="products_2603_09229.md",
-            ) as run_direct,
-            patch(
-                "arxiv2product.pipeline._run_pipeline_with_agentica",
-                new_callable=AsyncMock,
-            ) as run_agentica,
+            patch("arxiv2product.pipeline._run_pipeline", new_callable=AsyncMock, return_value="products_2603_09229.md") as run_agno,
+            patch("arxiv2product.pipeline._get_speed_profile", return_value="slow"),
         ):
             from arxiv2product.pipeline import run_pipeline
 
-            output = await run_pipeline("2603.09229")
+            output = await run_pipeline("2603.09229", model="anthropic/claude-sonnet-4")
 
         self.assertEqual(output, "products_2603_09229.md")
-        run_direct.assert_awaited_once_with("2603.09229", "anthropic/claude-sonnet-4", "backend")
-        run_agentica.assert_not_awaited()
+        run_agno.assert_awaited_once_with("2603.09229", "anthropic/claude-sonnet-4")
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_spawn_agent.py
+++ b/cli/tests/test_spawn_agent.py
@@ -1,107 +1,34 @@
 import asyncio
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
-import httpx
-
-from arxiv2product.errors import AgenticaConnectionError
+from arxiv2product.errors import AgentExecutionError
 
 
 class SpawnAgentTests(unittest.IsolatedAsyncioTestCase):
-    """Tests for spawn_agent timeout and connection error paths."""
+    """Tests for spawn_agent."""
 
-    @patch("arxiv2product.pipeline.spawn")
-    async def test_spawn_agent_raises_on_asyncio_timeout(self, mock_spawn):
-        """Hanging backend connections should raise AgenticaConnectionError."""
+    async def test_spawn_agent_creates_agno_agent(self):
+        """Verify Agno agent creation."""
         from arxiv2product.pipeline import spawn_agent
+        from agno.agent import Agent
 
-        async def hang_forever(**kwargs):
-            await asyncio.sleep(9999)
+        agent = await spawn_agent(premise="test", model="test-model")
+        self.assertIsInstance(agent, Agent)
+        self.assertEqual(agent.description, "test")
 
-        mock_spawn.side_effect = hang_forever
-
-        with patch("arxiv2product.pipeline.SPAWN_TIMEOUT_SECONDS", 0.1):
-            with self.assertRaises(AgenticaConnectionError) as ctx:
-                await spawn_agent(premise="test", model="test-model")
-            self.assertIn("Timed out after", str(ctx.exception))
-
-    @patch("arxiv2product.pipeline.spawn")
-    async def test_spawn_agent_raises_on_httpx_timeout(self, mock_spawn):
-        """httpx.TimeoutException during spawn should be wrapped."""
-        from arxiv2product.pipeline import spawn_agent
-
-        mock_spawn.side_effect = httpx.TimeoutException("connect timeout")
-
-        with self.assertRaises(AgenticaConnectionError) as ctx:
-            await spawn_agent(premise="test", model="test-model")
-        self.assertIn("Timed out while connecting", str(ctx.exception))
-
-    @patch("arxiv2product.pipeline.spawn")
-    async def test_spawn_agent_raises_on_httpx_http_error(self, mock_spawn):
-        """General httpx.HTTPError during spawn should be wrapped."""
-        from arxiv2product.pipeline import spawn_agent
-
-        mock_spawn.side_effect = httpx.HTTPError("503 Service Unavailable")
-
-        with self.assertRaises(AgenticaConnectionError) as ctx:
-            await spawn_agent(premise="test", model="test-model")
-        self.assertIn("Agentica request failed", str(ctx.exception))
-
-    @patch("arxiv2product.pipeline.spawn")
-    async def test_spawn_agent_disables_listener_by_default(self, mock_spawn):
-        """Listener should be set to None when ENABLE_AGENT_LOGS is off."""
-        from arxiv2product.pipeline import spawn_agent
-
-        mock_spawn.return_value = MagicMock()
-
-        with patch.dict("os.environ", {"ENABLE_AGENT_LOGS": "0"}, clear=False):
-            await spawn_agent(premise="test", model="test-model")
-
-        _, kwargs = mock_spawn.call_args
-        self.assertIsNone(kwargs.get("listener"))
-
-    @patch("arxiv2product.pipeline.spawn")
-    async def test_spawn_agent_keeps_listener_when_logs_enabled(self, mock_spawn):
-        """Listener should NOT be forced to None when logs are enabled."""
-        from arxiv2product.pipeline import spawn_agent
-
-        mock_spawn.return_value = MagicMock()
-
-        with patch.dict("os.environ", {"ENABLE_AGENT_LOGS": "1"}, clear=False):
-            await spawn_agent(premise="test", model="test-model")
-
-        _, kwargs = mock_spawn.call_args
-        self.assertNotIn("listener", kwargs)
-
-
-class CallAgentTextTeardownTests(unittest.IsolatedAsyncioTestCase):
-    """Tests for graceful agent teardown in call_agent_text."""
-
-    async def test_call_agent_text_calls_close_on_success(self):
-        """Agent.close() should be called even on the happy path."""
+    async def test_call_agent_text_runs_agent(self):
+        """Verify call_agent_text uses Agno's run method."""
         from arxiv2product.pipeline import call_agent_text
+        from agno.agent import Agent
+        from agno.models.message import Message
 
-        agent = AsyncMock()
-        agent.call.return_value = "result"
-        agent.close = AsyncMock()
+        agent = AsyncMock(spec=Agent)
+        agent.run.return_value = AsyncMock(content="result")
 
         result = await call_agent_text(agent, "prompt", phase="test")
         self.assertEqual(result, "result")
-        agent.close.assert_awaited_once()
-
-    async def test_call_agent_text_calls_close_on_failure(self):
-        """Agent.close() should be attempted even when the call fails."""
-        from arxiv2product.errors import AgentExecutionError
-        from arxiv2product.pipeline import call_agent_text
-
-        agent = AsyncMock()
-        agent.call.side_effect = asyncio.TimeoutError()
-        agent.close = AsyncMock()
-
-        with self.assertRaises(AgentExecutionError):
-            await call_agent_text(agent, "prompt", phase="test")
-
-        agent.close.assert_awaited_once()
+        agent.run.assert_called_once_with("prompt")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Add project docs + migrate Agentica → Agno

This PR does two main things:

1. Adds proper documentation for the project
2. Migrates the core agent framework from **Agentica to Agno**

---

### Documentation

Added a `.docs/` folder with detailed documentation about how the project works.

```
.docs/
 ├── README.md
 ├── architecture.md
 ├── tech_stack.md
 └── workflows.md
```

**Contents:**

* **README.md** – overview of the project and its philosophy
* **architecture.md** – explains the 5-phase pipeline with a flow diagram
* **tech_stack.md** – documents all external tools/APIs used
* **workflows.md** – instructions for using the CLI, API, topic discovery, and competitor intel

The architecture doc also explains the pipeline stages:

* Decomposer
* Pain Scanner
* Infrastructure Inversion
* Temporal Arbitrage
* Red Team Destroyer

---

### Framework migration (Agentica → Agno)

Replaced the Agentica framework with **Agno**.

Main changes:

* Agents now use `agno.agent.Agent`
* Replaced `agentica.spawn` and `.call()` with Agno's `.run()`
* Simplified backend to use:

  * `agno.models.openrouter.OpenRouter`
  * `agno.models.openai.OpenAIChat`

---

### Tools

Search tools were refactored to work with Agno’s tool system:

* `arxiv_search`
* `web_search`
* `parallel_search`
* `tinyfish_browse`

Added proper PEP-257 docstrings so they register cleanly.

---

### Dependencies

Updated `pyproject.toml`

Removed:

```
symbolica-agentica
```

Added:

```
agno
openai
```


